### PR TITLE
Api provides users to see upcoming trips

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,6 +8,7 @@ gem 'puma', '~> 4.1'
 gem 'bootsnap', '>= 1.4.2', require: false
 gem 'rack-cors', require: 'rack/cors'
 gem 'devise_token_auth'
+gem 'active_model_serializers'
 
 group :development, :test do
   gem 'pry-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -37,6 +37,11 @@ GEM
       erubi (~> 1.4)
       rails-dom-testing (~> 2.0)
       rails-html-sanitizer (~> 1.1, >= 1.2.0)
+    active_model_serializers (0.10.10)
+      actionpack (>= 4.1, < 6.1)
+      activemodel (>= 4.1, < 6.1)
+      case_transform (>= 0.2)
+      jsonapi-renderer (>= 0.1.1.beta1, < 0.3)
     activejob (6.0.2.2)
       activesupport (= 6.0.2.2)
       globalid (>= 0.3.6)
@@ -61,6 +66,8 @@ GEM
       msgpack (~> 1.0)
     builder (3.2.4)
     byebug (11.1.1)
+    case_transform (0.2)
+      activesupport
     coderay (1.1.2)
     concurrent-ruby (1.1.6)
     coveralls (0.8.23)
@@ -94,6 +101,7 @@ GEM
     i18n (1.8.2)
       concurrent-ruby (~> 1.0)
     json (2.3.0)
+    jsonapi-renderer (0.2.2)
     listen (3.1.5)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
@@ -220,6 +228,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  active_model_serializers
   bootsnap (>= 1.4.2)
   coveralls
   devise_token_auth

--- a/app/controllers/pings_controller.rb
+++ b/app/controllers/pings_controller.rb
@@ -11,7 +11,11 @@ class PingsController < ApplicationController
 
   def index
     pings = Ping.all.where(active: true)
-    render json: pings, each_serializer: PingIndexSerializer
+    if pings.length > 0
+      render json: pings, each_serializer: PingIndexSerializer
+    else
+      render json: { message: "Unfortunately no one has planned to go shopping, so maybe you can?" }
+    end
   end
 
   private

--- a/app/controllers/pings_controller.rb
+++ b/app/controllers/pings_controller.rb
@@ -9,6 +9,11 @@ class PingsController < ApplicationController
     end
   end
 
+  def index
+    pings = Ping.all.where(active: true)
+    render json: pings, each_serializer: PingIndexSerializer
+  end
+
   private
 
   def ping_params

--- a/app/serializers/ping_index_serializer.rb
+++ b/app/serializers/ping_index_serializer.rb
@@ -1,0 +1,3 @@
+class PingIndexSerializer < ActiveModel::Serializer
+  attributes :id, :time, :store
+end

--- a/app/serializers/ping_index_serializer.rb
+++ b/app/serializers/ping_index_serializer.rb
@@ -1,3 +1,7 @@
 class PingIndexSerializer < ActiveModel::Serializer
   attributes :id, :time, :store
+
+  def time
+    object.time.strftime('%Y-%m-%d %H:%M')
+  end
 end

--- a/config/initializers/ams.rb
+++ b/config/initializers/ams.rb
@@ -1,0 +1,1 @@
+ActiveModelSerializers.config.adapter = :json

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,4 @@
 Rails.application.routes.draw do
     mount_devise_token_auth_for 'User', at: '/auth', skip: [:omniauth_callbacks]
-    resources :pings, only: [:create]
+    resources :pings, only: [:create, :index]
 end

--- a/spec/requests/user_can_see_upcoming_pings_spec.rb
+++ b/spec/requests/user_can_see_upcoming_pings_spec.rb
@@ -1,0 +1,22 @@
+RSpec.describe 'GET /pings', type: :request do
+  let(:ping) { create(:ping, time: '2020-04-14 14:00', store: 'Coop') }
+  let(:ping2) { create(:ping, time: '2020-04-14 10:00', store: 'Systembolaget') }
+
+  describe 'user can see upcoming pings' do
+    before do
+      get '/pings'
+    end
+
+    it 'returns 200 response' do
+      expect(response.status).to eq 200
+    end
+
+    it 'can see list of upcoming pings' do
+      expect(reponse_json['pings'].count).to eq 2
+    end
+
+    it 'can see list of upcoming pings' do
+      expect(reponse_json['pings'].first['store']).to eq 'Coop'
+    end
+  end
+end

--- a/spec/requests/user_can_see_upcoming_pings_spec.rb
+++ b/spec/requests/user_can_see_upcoming_pings_spec.rb
@@ -1,10 +1,11 @@
-RSpec.describe 'GET /pings', type: :request do
-  let!(:pings) { create(:ping, time: '2020-04-14 14:00', store: 'Coop') }
-  let!(:pings2) do
-    create(:ping, time: '2020-04-14 10:00', store: 'Systembolaget')
-  end
+# frozen_string_literal: true
 
+RSpec.describe 'GET /pings', type: :request do
   describe 'user can see upcoming pings' do
+    let!(:pings) { create(:ping, time: '2020-04-14 14:00', store: 'Coop') }
+    let!(:pings2) { create(:ping, time: '2020-04-14 10:00', store: 'Systembolaget') }
+    let!(:pings3) { create(:ping, time: '2020-04-12 15:00', store: 'Ica', active: false) }
+
     before { get '/pings' }
 
     it 'returns 200 response' do
@@ -17,6 +18,20 @@ RSpec.describe 'GET /pings', type: :request do
 
     it 'can see list of upcoming pings' do
       expect(response_json['pings'].first['store']).to eq 'Coop'
+    end
+
+    it 'does not see pings that are not active' do
+      expect(response_json['pings'].last['time']).to eq '2020-04-14 10:00'
+    end
+  end
+
+  describe 'receives message if there are no pings' do
+    let!(:pings) { create(:ping, time: '2020-04-14 14:00', store: 'Coop', active: false) }
+
+    before { get '/pings' }
+
+    it 'returns message about no active pings' do
+      expect(response_json['message']).to eq 'Unfortunately no one has planned to go shopping, so maybe you can?'
     end
   end
 end

--- a/spec/requests/user_can_see_upcoming_pings_spec.rb
+++ b/spec/requests/user_can_see_upcoming_pings_spec.rb
@@ -1,22 +1,22 @@
 RSpec.describe 'GET /pings', type: :request do
-  let(:ping) { create(:ping, time: '2020-04-14 14:00', store: 'Coop') }
-  let(:ping2) { create(:ping, time: '2020-04-14 10:00', store: 'Systembolaget') }
+  let!(:pings) { create(:ping, time: '2020-04-14 14:00', store: 'Coop') }
+  let!(:pings2) do
+    create(:ping, time: '2020-04-14 10:00', store: 'Systembolaget')
+  end
 
   describe 'user can see upcoming pings' do
-    before do
-      get '/pings'
-    end
+    before { get '/pings' }
 
     it 'returns 200 response' do
       expect(response.status).to eq 200
     end
 
     it 'can see list of upcoming pings' do
-      expect(reponse_json['pings'].count).to eq 2
+      expect(response_json['pings'].count).to eq 2
     end
 
     it 'can see list of upcoming pings' do
-      expect(reponse_json['pings'].first['store']).to eq 'Coop'
+      expect(response_json['pings'].first['store']).to eq 'Coop'
     end
   end
 end


### PR DESCRIPTION
## [PT board URL](https://www.pivotaltracker.com/story/show/172274828)
### User Story
```
As a resident 
In order view upcoming shopping trips and times
I would like to be able to see who and when will be shopping
```
## Changes proposed in this pull request:
* Adding index method to Pings controller only responding with active pings
* Adding active model serializer to sanitize the reponse
* Modifying the format of how the time is formatted in the response

## What I have learned working on this feature:
* How to modify the format of a datetime datatype 

## Packages/Gems added
- active model serializer