### PR TITLE
Add association between User and Ping

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,3 +1,12 @@
 class ApplicationController < ActionController::API
-        include DeviseTokenAuth::Concerns::SetUserByToken
+  include DeviseTokenAuth::Concerns::SetUserByToken
+  before_action :configure_permitted_parameters, if: :devise_controller?
+
+  protected
+
+  def configure_permitted_parameters
+    added_attrs = %i[name email password password_confirmation]
+    devise_parameter_sanitizer.permit :sign_up, keys: added_attrs
+    devise_parameter_sanitizer.permit :account_update, keys: added_attrs
+  end
 end

--- a/app/controllers/pings_controller.rb
+++ b/app/controllers/pings_controller.rb
@@ -23,6 +23,6 @@ class PingsController < ApplicationController
   private
 
   def ping_params
-    params.require(:ping).permit(:time, :store)
+    params.require(:ping).permit(:time, :store, :user_id)
   end
 end

--- a/app/models/ping.rb
+++ b/app/models/ping.rb
@@ -1,3 +1,4 @@
 class Ping < ApplicationRecord
   validates_presence_of :time
+  belongs_to :user
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -7,4 +7,5 @@ class User < ActiveRecord::Base
   include DeviseTokenAuth::Concerns::User
   validates_presence_of :role
   enum role: [ :admin, :user ]
+  has_many :pings
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -5,7 +5,7 @@ class User < ActiveRecord::Base
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :trackable, :validatable
   include DeviseTokenAuth::Concerns::User
-  validates_presence_of :role
+  validates_presence_of :role, :name
   enum role: [ :admin, :user ]
   has_many :pings
 end

--- a/app/serializers/ping_index_serializer.rb
+++ b/app/serializers/ping_index_serializer.rb
@@ -1,7 +1,12 @@
 class PingIndexSerializer < ActiveModel::Serializer
-  attributes :id, :time, :store
+  attributes :id, :time, :store, :user_name
 
   def time
     object.time.strftime('%Y-%m-%d %H:%M')
+  end
+
+  def user_name
+    user = User.all.find(object.user_id)
+    user.name
   end
 end

--- a/db/migrate/20200413090809_create_pings.rb
+++ b/db/migrate/20200413090809_create_pings.rb
@@ -4,6 +4,7 @@ class CreatePings < ActiveRecord::Migration[6.0]
       t.datetime :time
       t.string :store
       t.boolean :active, default: true
+      
       t.timestamps
     end
   end

--- a/db/migrate/20200413163916_add_association_to_ping.rb
+++ b/db/migrate/20200413163916_add_association_to_ping.rb
@@ -1,0 +1,7 @@
+class AddAssociationToPing < ActiveRecord::Migration[6.0]
+  def change
+    change_table :pings do |t|
+      t.belongs_to :user, null: false, foreign_key: true
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_04_13_090809) do
+ActiveRecord::Schema.define(version: 2020_04_13_163916) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -21,6 +21,8 @@ ActiveRecord::Schema.define(version: 2020_04_13_090809) do
     t.boolean "active", default: true
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.bigint "user_id", null: false
+    t.index ["user_id"], name: "index_pings_on_user_id"
   end
 
   create_table "users", force: :cascade do |t|
@@ -52,4 +54,5 @@ ActiveRecord::Schema.define(version: 2020_04_13_090809) do
     t.index ["uid", "provider"], name: "index_users_on_uid_and_provider", unique: true
   end
 
+  add_foreign_key "pings", "users"
 end

--- a/spec/factories/pings.rb
+++ b/spec/factories/pings.rb
@@ -2,5 +2,6 @@ FactoryBot.define do
   factory :ping do
     time { "2020-04-13 11:08:09" }
     store { "Ica" }
+    association :user, factory: :user
   end
 end

--- a/spec/models/ping_spec.rb
+++ b/spec/models/ping_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe Ping, type: :model do
   describe 'Database table' do
     it { is_expected.to have_db_column :time }
     it { is_expected.to have_db_column :store }
+    it { is_expected.to belong_to :user}
   end
   describe 'Validations' do
     it { is_expected.to validate_presence_of :time }

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -16,6 +16,7 @@ RSpec.describe User, type: :model do
   describe 'Validations' do
     it { is_expected.to validate_presence_of :email }
     it { is_expected.to validate_presence_of :role }
+    it { is_expected.to validate_presence_of :name }
     it { is_expected.to validate_confirmation_of :password }
 
     context 'should not have an invalid email address' do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -11,6 +11,7 @@ RSpec.describe User, type: :model do
     it { is_expected.to have_db_column :name }
     it { is_expected.to have_db_column :tokens }
     it { is_expected.to have_db_column :role}
+    it { is_expected.to have_many :pings }
   end
   describe 'Validations' do
     it { is_expected.to validate_presence_of :email }

--- a/spec/requests/registration_spec.rb
+++ b/spec/requests/registration_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe 'POST /auth', type: :request do
       post '/auth',
         params: {
           email: 'user@mail.com',
+          name: 'Betty',
           password: 'password',
           password_confirmation: 'password'
         },
@@ -84,6 +85,26 @@ RSpec.describe 'POST /auth', type: :request do
       it 'returns an error message' do
         expect(response_json['errors']['email']).to eq ['has already been taken']
       end
+    end
+  end
+  describe 'an invalid email address' do
+    before do
+      post '/auth',
+        params: {
+          email: 'user@mail',
+          password: 'password',
+          password_confirmation: 'password',
+          name: ''
+        },
+        headers: headers
+    end
+
+    it 'returns a 422 response status' do
+      expect(response).to have_http_status 422
+    end
+
+    it 'returns an error message' do
+      expect(response_json['errors']['name']).to eq ["can't be blank"]
     end
   end
 end

--- a/spec/requests/user_can_create_ping_spec.rb
+++ b/spec/requests/user_can_create_ping_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe 'post /pings', type: :request do
     describe 'user POST a ping' do
       before do
         post '/pings',
-             params: { ping: { time: '2020-04-31-15:00', store: 'ica' } },
+             params: { ping: { time: '2020-04-31-15:00', store: 'ica', user_id: user.id } },
              headers: user_headers
       end
 
@@ -26,7 +26,7 @@ RSpec.describe 'post /pings', type: :request do
     describe 'user POST a ping without store' do
       before do
         post '/pings',
-             params: { ping: { time: '2020-04-31-15:00' } },
+             params: { ping: { time: '2020-04-31-15:00', user_id: user.id } },
              headers: user_headers
       end
 
@@ -40,7 +40,8 @@ RSpec.describe 'post /pings', type: :request do
 
     describe 'user POST a ping without time' do
       before do
-        post '/pings', params: { ping: { store: 'Ica' } }, headers: user_headers
+        post '/pings', params: { ping: { store: 'Ica', user_id: user.id } }, 
+        headers: user_headers
       end
       it 'returns a 422 response status' do
         expect(response).to have_http_status 422
@@ -64,7 +65,7 @@ RSpec.describe 'post /pings', type: :request do
       expect(response).to have_http_status 401
     end
     it 'returns success message' do
-      expect(response_json['errors'].first).to eq "You need to sign in or sign up before continuing."
+      expect(response_json['errors'].first).to eq 'You need to sign in or sign up before continuing.'
     end
   end
 end

--- a/spec/requests/user_can_see_upcoming_pings_spec.rb
+++ b/spec/requests/user_can_see_upcoming_pings_spec.rb
@@ -9,12 +9,12 @@ RSpec.describe 'GET /pings', type: :request do
     end
 
     describe 'user can see upcoming pings' do
-      let!(:pings) { create(:ping, time: '2020-04-14 14:00', store: 'Coop') }
+      let!(:pings) { create(:ping, time: '2020-04-14 14:00', store: 'Coop', user_id: user.id) }
       let!(:pings2) do
-        create(:ping, time: '2020-04-14 10:00', store: 'Systembolaget')
+        create(:ping, time: '2020-04-14 10:00', store: 'Systembolaget', user_id: user.id)
       end
       let!(:pings3) do
-        create(:ping, time: '2020-04-12 15:00', store: 'Ica', active: false)
+        create(:ping, time: '2020-04-12 15:00', store: 'Ica', active: false, user_id: user.id)
       end
       before { get '/pings', headers: user_headers }
 
@@ -33,11 +33,15 @@ RSpec.describe 'GET /pings', type: :request do
       it 'does not see pings that are not active' do
         expect(response_json['pings'].last['time']).to eq '2020-04-14 10:00'
       end
+
+      it 'return name of ping creator' do
+        expect(response_json['pings'].first['user_name']).to eq 'Betty'
+      end
     end
 
     describe 'receives message if there are no pings' do
       let!(:pings) do
-        create(:ping, time: '2020-04-14 14:00', store: 'Coop', active: false)
+        create(:ping, time: '2020-04-14 14:00', store: 'Coop', active: false, user_id: user.id)
       end
 
       before { get '/pings', headers: user_headers }


### PR DESCRIPTION
## [PT board URL](https://www.pivotaltracker.com/story/show/172285696)
### User Story
```
As a development team
In order to link the users with their pings
We need to add association between user and pings after user authentication is in place
```
## Changes proposed in this pull request:
* Active model association between user has many pings and ping belongs to user
* Adding name to user when signing up
* Sending name of user that ping belongs to with index method

## What I have learned working on this feature:
* How to override the devise token auth to add name with sign up
* How to add association to factory bot 
