### PR TITLE
Api provides admin to accept or reject users to their community

### DIFF
--- a/app/controllers/admin/communities_controller.rb
+++ b/app/controllers/admin/communities_controller.rb
@@ -15,7 +15,8 @@ class Admin::CommunitiesController < ApplicationController
   end
 
   def index
-    
+    pending_community_users = User.all.where(community_id: current_user.community_id).where(community_status: 'pending')
+    render json: { requests: pending_community_users }
   end
 
   private

--- a/app/controllers/admin/communities_controller.rb
+++ b/app/controllers/admin/communities_controller.rb
@@ -16,7 +16,11 @@ class Admin::CommunitiesController < ApplicationController
 
   def index
     pending_community_users = User.all.where(community_id: current_user.community_id).where(community_status: 'pending')
-    render json: { requests: pending_community_users }
+    if pending_community_users.any?
+      render json: { requests: pending_community_users }
+    else
+      render json: { message: 'You have no pending requests to your community' }
+    end
   end
 
   private

--- a/app/controllers/admin/communities_controller.rb
+++ b/app/controllers/admin/communities_controller.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+class Admin::CommunitiesController < ApplicationController
+  before_action :authenticate_user!
+  before_action :is_user_admin
+
+  def update
+    if accept_user? == 'accepted'
+      update_user_community_status
+      render json: { message: 'User is now accepted to your community' }
+    else
+      update_user_community_status
+      render json: { message: 'User is now rejected from your community' }
+    end
+  end
+
+  def index
+    
+  end
+
+  private
+
+  def user_admission
+    params.require(:user_admission).permit(:community_id, :community_status, :user_id)
+  end
+
+  def accept_user?
+    user_admission['community_status']
+  end
+
+  def update_user_community_status
+    user = User.all.find(user_admission['user_id']).update(community_status: accept_user?)
+  end
+
+  def is_user_admin
+    if current_user.role == 'admin'
+    else
+      render json: { message: 'You are not authorized to do this, ask your admin' },
+             status: 401
+    end
+  end
+end

--- a/app/controllers/communities_controller.rb
+++ b/app/controllers/communities_controller.rb
@@ -1,10 +1,15 @@
 # frozen_string_literal: true
 
 class CommunitiesController < ApplicationController
+  before_action :authenticate_user!
   def index
     id = Community.all.select { |community| community.code == params['q'] }.first.id
     render json: { community_id: id }
   rescue StandardError => e
     render json: { message: 'There is unfortunately no community with this code, did you type it correctly?' }
+  end
+
+  def update
+    render json: { message: 'User is now accepted to your community.' }
   end
 end

--- a/app/controllers/communities_controller.rb
+++ b/app/controllers/communities_controller.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
 class CommunitiesController < ApplicationController
-  before_action :authenticate_user!
-  before_action :is_user_admin, only: :update
+  before_action :authenticate_user!, only: [:update]
+  before_action :is_user_admin, only: [:update]
   def index
     id = Community.all.select { |community| community.code == params['q'] }.first.id
     render json: { community_id: id }
@@ -17,8 +17,8 @@ class CommunitiesController < ApplicationController
     else
       update_user_community_status
       render json: { message: 'User is now rejected from your community' }
+    end
   end
-end
 
   private
 

--- a/app/controllers/communities_controller.rb
+++ b/app/controllers/communities_controller.rb
@@ -1,44 +1,11 @@
 # frozen_string_literal: true
 
 class CommunitiesController < ApplicationController
-  before_action :authenticate_user!, only: [:update]
-  before_action :is_user_admin, only: [:update]
+
   def index
     id = Community.all.select { |community| community.code == params['q'] }.first.id
     render json: { community_id: id }
   rescue StandardError => e
     render json: { message: 'There is unfortunately no community with this code, did you type it correctly?' }
-  end
-
-  def update
-    if accept_user? == 'accepted'
-      update_user_community_status
-      render json: { message: 'User is now accepted to your community' }
-    else
-      update_user_community_status
-      render json: { message: 'User is now rejected from your community' }
-    end
-  end
-
-  private
-
-  def user_admission
-    params.require(:user_admission).permit(:community_id, :community_status, :user_id )
-  end
-
-  def accept_user?
-    user_admission['community_status']
-  end
-
-  def update_user_community_status
-    user = User.all.find(user_admission['user_id']).update(community_status: accept_user? )
-  end
-
-  def is_user_admin
-    if current_user.role == "admin"
-    else
-      render json: { message: 'You are not authorized to do this, ask your admin' },
-      status: 401
-    end
   end
 end

--- a/app/controllers/communities_controller.rb
+++ b/app/controllers/communities_controller.rb
@@ -2,6 +2,7 @@
 
 class CommunitiesController < ApplicationController
   before_action :authenticate_user!
+  before_action :is_user_admin, only: :update
   def index
     id = Community.all.select { |community| community.code == params['q'] }.first.id
     render json: { community_id: id }
@@ -10,6 +11,34 @@ class CommunitiesController < ApplicationController
   end
 
   def update
-    render json: { message: 'User is now accepted to your community.' }
+    if accept_user? == 'accepted'
+      update_user_community_status
+      render json: { message: 'User is now accepted to your community' }
+    else
+      update_user_community_status
+      render json: { message: 'User is now rejected from your community' }
+  end
+end
+
+  private
+
+  def user_admission
+    params.require(:user_admission).permit(:community_id, :community_status, :user_id )
+  end
+
+  def accept_user?
+    user_admission['community_status']
+  end
+
+  def update_user_community_status
+    user = User.all.find(user_admission['user_id']).update(community_status: accept_user? )
+  end
+
+  def is_user_admin
+    if current_user.role == "admin"
+    else
+      render json: { message: 'You are not authorized to do this, ask your admin' },
+      status: 401
+    end
   end
 end

--- a/app/controllers/pings_controller.rb
+++ b/app/controllers/pings_controller.rb
@@ -2,6 +2,7 @@
 
 class PingsController < ApplicationController
   before_action :authenticate_user!
+  before_action :is_part_of_community?
 
   def create
     ping = Ping.create(ping_params)
@@ -25,5 +26,13 @@ class PingsController < ApplicationController
 
   def ping_params
     params.require(:ping).permit(:time, :store, :user_id)
+  end
+
+  def is_part_of_community?
+    if current_user.community_status == 'accepted'
+    else
+      render json: { message: 'You are not part of a community yet, ask your admin for more information' },
+      status: 401
+    end
   end
 end

--- a/app/controllers/pongs_controller.rb
+++ b/app/controllers/pongs_controller.rb
@@ -2,9 +2,11 @@
 
 class PongsController < ApplicationController
   before_action :authenticate_user!
+  before_action :is_part_of_community?
   before_action :verify_ping_and_user
   before_action :get_pong_owner
   before_action :get_ping
+  
   def create
     if @pong_owner.has_active_pongs?
       render_error('You can only have one active request')
@@ -16,6 +18,13 @@ class PongsController < ApplicationController
   end
 
   private
+
+  def is_part_of_community?
+    if current_user.community_status == 'accepted'
+    else
+      render json: { message: 'You are not part of a community yet, ask your admin for more information' }, status: 401
+    end
+  end
 
   def pong_params
     params.require(:pong).permit(:item1, :item2, :item3, :user_id, :ping_id)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,6 @@
 Rails.application.routes.draw do
-  get 'pongs/create'
     mount_devise_token_auth_for 'User', at: '/auth', skip: [:omniauth_callbacks]
     resources :pings, only: [:create, :index]
     resources :pongs, only: [:create]
-    resources :communities, only: [:index]
+    resources :communities, only: [:index, :update]
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,5 +2,8 @@ Rails.application.routes.draw do
     mount_devise_token_auth_for 'User', at: '/auth', skip: [:omniauth_callbacks]
     resources :pings, only: [:create, :index]
     resources :pongs, only: [:create]
-    resources :communities, only: [:index, :update]
+    resources :communities, only: [:index]
+    namespace :admin do
+        resources :communities, only: [:index, :update]
+    end
 end

--- a/spec/requests/admin_can_accept_or_reject_user_spec.rb
+++ b/spec/requests/admin_can_accept_or_reject_user_spec.rb
@@ -1,4 +1,5 @@
 RSpec.describe 'PUT /communities', type: :request do
+  let(:community) { create(:community) }
   let(:user) { create(:user, role: 'user', community_status: 'pending') }
     let(:user_credentials) { user.create_new_auth_token }
     let(:user_headers) do
@@ -9,12 +10,12 @@ RSpec.describe 'PUT /communities', type: :request do
     let(:admin_headers) do
       { HTTP_ACCEPT: 'application/json' }.merge!(admin_credentials)
     end
-    describe 'admin can accept or reject user to community' do
-      let(:community) { create(:community) } 
+    describe 'admin can accept user to community' do
+       
       before do
         put "/communities/#{community.id}",
              params: {
-               user: {
+               user_admission: {
                  community_id: community.id,
                  community_status: 'accepted',
                  user_id: user.id
@@ -28,7 +29,59 @@ RSpec.describe 'PUT /communities', type: :request do
       end
       
       it 'returns success message' do
-        expect(response_json['message']).to eq 'User is now accepted to your community.'
+        expect(response_json['message']).to eq 'User is now accepted to your community'
       end
+
+      it 'admin can accept user admission' do
+        expect(User.all.find(user.id).community_status).to eq 'accepted'
+      end
+
+      
+    end
+
+    describe 'admin can reject user to community' do
+      before do
+        put "/communities/#{community.id}",
+             params: {
+               user_admission: {
+                 community_id: community.id,
+                 community_status: 'rejected',
+                 user_id: user.id
+               }
+             },
+             headers: admin_headers
+      end
+
+      it 'returns success message' do
+        expect(response_json['message']).to eq 'User is now rejected from your community'
+      end
+
+      it 'admin can reject user admission' do
+        expect(User.all.find(user.id).community_status).to eq 'rejected'
+      end
+    end
+
+    describe 'only admin can change community status' do
+      before do
+        put "/communities/#{community.id}",
+             params: {
+               user_admission: {
+                 community_id: community.id,
+                 community_status: 'rejected',
+                 user_id: user.id
+               }
+             },
+             headers: user_headers
+      end
+
+      it 'returns a 401 response status' do
+        expect(response).to have_http_status 401
+      end
+
+      it 'returns error message' do
+        expect(response_json['message']).to eq 'You are not authorized to do this, ask your admin'
+      end
+
+     
     end
 end

--- a/spec/requests/admin_can_accept_or_reject_user_spec.rb
+++ b/spec/requests/admin_can_accept_or_reject_user_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe 'PUT /communities', type: :request do
   end
   describe 'admin can accept user to community' do
     before do
-      put "/communities/#{community.id}",
+      put "/admin/communities/#{community.id}",
           params: {
             user_admission: {
               community_id: community.id,
@@ -40,7 +40,7 @@ RSpec.describe 'PUT /communities', type: :request do
 
   describe 'admin can reject user to community' do
     before do
-      put "/communities/#{community.id}",
+      put "/admin/communities/#{community.id}",
           params: {
             user_admission: {
               community_id: community.id,
@@ -62,7 +62,7 @@ RSpec.describe 'PUT /communities', type: :request do
 
   describe 'only admin can change community status' do
     before do
-      put "/communities/#{community.id}",
+      put "/admin/communities/#{community.id}",
           params: {
             user_admission: {
               community_id: community.id,

--- a/spec/requests/admin_can_accept_or_reject_user_spec.rb
+++ b/spec/requests/admin_can_accept_or_reject_user_spec.rb
@@ -2,16 +2,19 @@
 
 RSpec.describe 'PUT /communities', type: :request do
   let(:community) { create(:community) }
+  
   let(:user) { create(:user, role: 'user', community_status: 'pending') }
   let(:user_credentials) { user.create_new_auth_token }
   let(:user_headers) do
     { HTTP_ACCEPT: 'application/json' }.merge!(user_credentials)
   end
+
   let(:admin) { create(:user, role: 'admin') }
   let(:admin_credentials) { admin.create_new_auth_token }
   let(:admin_headers) do
     { HTTP_ACCEPT: 'application/json' }.merge!(admin_credentials)
   end
+
   describe 'admin can accept user to community' do
     before do
       put "/admin/communities/#{community.id}",

--- a/spec/requests/admin_can_accept_or_reject_user_spec.rb
+++ b/spec/requests/admin_can_accept_or_reject_user_spec.rb
@@ -1,0 +1,34 @@
+RSpec.describe 'PUT /communities', type: :request do
+  let(:user) { create(:user, role: 'user', community_status: 'pending') }
+    let(:user_credentials) { user.create_new_auth_token }
+    let(:user_headers) do
+      { HTTP_ACCEPT: 'application/json' }.merge!(user_credentials)
+    end
+    let(:admin) { create(:user, role: 'admin') }
+    let(:admin_credentials) { admin.create_new_auth_token }
+    let(:admin_headers) do
+      { HTTP_ACCEPT: 'application/json' }.merge!(admin_credentials)
+    end
+    describe 'admin can accept or reject user to community' do
+      let(:community) { create(:community) } 
+      before do
+        put "/communities/#{community.id}",
+             params: {
+               user: {
+                 community_id: community.id,
+                 community_status: 'accepted',
+                 user_id: user.id
+               }
+             },
+             headers: admin_headers
+      end
+
+      it 'returns a 200 response status' do
+        expect(response).to have_http_status 200
+      end
+      
+      it 'returns success message' do
+        expect(response_json['message']).to eq 'User is now accepted to your community.'
+      end
+    end
+end

--- a/spec/requests/admin_can_accept_or_reject_user_spec.rb
+++ b/spec/requests/admin_can_accept_or_reject_user_spec.rb
@@ -1,87 +1,84 @@
+# frozen_string_literal: true
+
 RSpec.describe 'PUT /communities', type: :request do
   let(:community) { create(:community) }
   let(:user) { create(:user, role: 'user', community_status: 'pending') }
-    let(:user_credentials) { user.create_new_auth_token }
-    let(:user_headers) do
-      { HTTP_ACCEPT: 'application/json' }.merge!(user_credentials)
-    end
-    let(:admin) { create(:user, role: 'admin') }
-    let(:admin_credentials) { admin.create_new_auth_token }
-    let(:admin_headers) do
-      { HTTP_ACCEPT: 'application/json' }.merge!(admin_credentials)
-    end
-    describe 'admin can accept user to community' do
-       
-      before do
-        put "/communities/#{community.id}",
-             params: {
-               user_admission: {
-                 community_id: community.id,
-                 community_status: 'accepted',
-                 user_id: user.id
-               }
-             },
-             headers: admin_headers
-      end
-
-      it 'returns a 200 response status' do
-        expect(response).to have_http_status 200
-      end
-      
-      it 'returns success message' do
-        expect(response_json['message']).to eq 'User is now accepted to your community'
-      end
-
-      it 'admin can accept user admission' do
-        expect(User.all.find(user.id).community_status).to eq 'accepted'
-      end
-
-      
+  let(:user_credentials) { user.create_new_auth_token }
+  let(:user_headers) do
+    { HTTP_ACCEPT: 'application/json' }.merge!(user_credentials)
+  end
+  let(:admin) { create(:user, role: 'admin') }
+  let(:admin_credentials) { admin.create_new_auth_token }
+  let(:admin_headers) do
+    { HTTP_ACCEPT: 'application/json' }.merge!(admin_credentials)
+  end
+  describe 'admin can accept user to community' do
+    before do
+      put "/communities/#{community.id}",
+          params: {
+            user_admission: {
+              community_id: community.id,
+              community_status: 'accepted',
+              user_id: user.id
+            }
+          },
+          headers: admin_headers
     end
 
-    describe 'admin can reject user to community' do
-      before do
-        put "/communities/#{community.id}",
-             params: {
-               user_admission: {
-                 community_id: community.id,
-                 community_status: 'rejected',
-                 user_id: user.id
-               }
-             },
-             headers: admin_headers
-      end
-
-      it 'returns success message' do
-        expect(response_json['message']).to eq 'User is now rejected from your community'
-      end
-
-      it 'admin can reject user admission' do
-        expect(User.all.find(user.id).community_status).to eq 'rejected'
-      end
+    it 'returns a 200 response status' do
+      expect(response).to have_http_status 200
     end
 
-    describe 'only admin can change community status' do
-      before do
-        put "/communities/#{community.id}",
-             params: {
-               user_admission: {
-                 community_id: community.id,
-                 community_status: 'rejected',
-                 user_id: user.id
-               }
-             },
-             headers: user_headers
-      end
-
-      it 'returns a 401 response status' do
-        expect(response).to have_http_status 401
-      end
-
-      it 'returns error message' do
-        expect(response_json['message']).to eq 'You are not authorized to do this, ask your admin'
-      end
-
-     
+    it 'returns success message' do
+      expect(response_json['message']).to eq 'User is now accepted to your community'
     end
+
+    it 'admin can accept user admission' do
+      expect(User.all.find(user.id).community_status).to eq 'accepted'
+    end
+  end
+
+  describe 'admin can reject user to community' do
+    before do
+      put "/communities/#{community.id}",
+          params: {
+            user_admission: {
+              community_id: community.id,
+              community_status: 'rejected',
+              user_id: user.id
+            }
+          },
+          headers: admin_headers
+    end
+
+    it 'returns success message' do
+      expect(response_json['message']).to eq 'User is now rejected from your community'
+    end
+
+    it 'admin can reject user admission' do
+      expect(User.all.find(user.id).community_status).to eq 'rejected'
+    end
+  end
+
+  describe 'only admin can change community status' do
+    before do
+      put "/communities/#{community.id}",
+          params: {
+            user_admission: {
+              community_id: community.id,
+              community_status: 'rejected',
+              user_id: user.id
+            }
+          },
+          headers: user_headers
+    end
+
+    it 'returns a 401 response status' do
+      expect(response).to have_http_status 401
+    end
+
+    it 'returns error message' do
+      expect(response_json['message']).to eq 'You are not authorized to do this, ask your admin'
+    end
+  end
 end

--- a/spec/requests/admin_can_see_pending_request_spec.rb
+++ b/spec/requests/admin_can_see_pending_request_spec.rb
@@ -1,36 +1,47 @@
+# frozen_string_literal: true
+
 RSpec.describe 'GET /admin/communities', type: :request do
-  let(:community) { create(:community) }
-  let!(:user) { create(:user, role: 'user', community_status: 'pending', community_id: community.id) }
-  let!(:user2) { create(:user, role: 'user', community_status: 'pending', community_id: community.id) }
-  let!(:user3) { create(:user, role: 'user', community_status: 'accepted', community_id: community.id) }
-  let!(:user4) { create(:user, role: 'user', community_status: 'pending') }
+  describe 'successfully' do
+    let(:community) { create(:community) }
+    let!(:user3) { create(:user, role: 'user', community_status: 'accepted', community_id: community.id) }
+    let!(:user4) { create(:user, role: 'user', community_status: 'pending') }
+    let(:admin) { create(:user, role: 'admin', community_id: community.id) }
+    let(:admin_credentials) { admin.create_new_auth_token }
+    let(:admin_headers) do
+      { HTTP_ACCEPT: 'application/json' }.merge!(admin_credentials)
+    end
 
-  let(:admin) { create(:user, role: 'admin', community_id: community.id) }
-  let(:admin_credentials) { admin.create_new_auth_token }
-  let(:admin_headers) do
-    { HTTP_ACCEPT: 'application/json' }.merge!(admin_credentials)
+    describe 'admin can see list of pending requests' do
+      let!(:user) { create(:user, role: 'user', community_status: 'pending', community_id: community.id) }
+      let!(:user2) { create(:user, role: 'user', community_status: 'pending', community_id: community.id) }
+
+      before do
+        get '/admin/communities',
+            headers: admin_headers
+      end
+
+      it 'returns a 200 response status' do
+        expect(response).to have_http_status 200
+      end
+
+      it 'returns all pending users to a community' do
+        expect(response_json['requests'].count).to eq 2
+      end
+
+      it 'returns correct community id' do
+        expect(response_json['requests'].first['community_id']).to eq community.id
+      end
+    end
+
+    describe 'there are no pending requests' do
+      before do
+        get '/admin/communities',
+            headers: admin_headers
+      end
+
+      it 'returns message about no pedning requests' do
+        expect(response_json['message']).to eq 'You have no pending requests to your community'
+      end
+    end
   end
-
-  describe 'admin can see list of pending requests' do 
-    before do
-      get "/admin/communities",
-      headers: admin_headers
-    end 
-
-    it 'returns a 200 response status' do
-      expect(response).to have_http_status 200
-    end
-
-    it 'returns all pending users to a community' do
-      expect(response_json['requests'].count).to eq 2
-    end
-
-    it 'returns correct community id' do
-      expect(response_json['requests'].first['community_id']).to eq community.id
-    end
-  end 
-
-
-
 end
-

--- a/spec/requests/admin_can_see_pending_request_spec.rb
+++ b/spec/requests/admin_can_see_pending_request_spec.rb
@@ -3,8 +3,10 @@
 RSpec.describe 'GET /admin/communities', type: :request do
   describe 'successfully' do
     let(:community) { create(:community) }
-    let!(:user3) { create(:user, role: 'user', community_status: 'accepted', community_id: community.id) }
-    let!(:user4) { create(:user, role: 'user', community_status: 'pending') }
+
+    let!(:user) { create(:user, role: 'user', community_status: 'accepted', community_id: community.id) }
+    let!(:user2) { create(:user, role: 'user', community_status: 'pending') }
+
     let(:admin) { create(:user, role: 'admin', community_id: community.id) }
     let(:admin_credentials) { admin.create_new_auth_token }
     let(:admin_headers) do
@@ -12,8 +14,8 @@ RSpec.describe 'GET /admin/communities', type: :request do
     end
 
     describe 'admin can see list of pending requests' do
-      let!(:user) { create(:user, role: 'user', community_status: 'pending', community_id: community.id) }
-      let!(:user2) { create(:user, role: 'user', community_status: 'pending', community_id: community.id) }
+      let!(:user3) { create(:user, role: 'user', community_status: 'pending', community_id: community.id) }
+      let!(:user4) { create(:user, role: 'user', community_status: 'pending', community_id: community.id) }
 
       before do
         get '/admin/communities',
@@ -47,11 +49,13 @@ RSpec.describe 'GET /admin/communities', type: :request do
 
   describe 'only admin can change community status' do
     let(:community) { create(:community) }
+
     let(:user) { create(:user, role: 'user', community_status: 'pending') }
     let(:user_credentials) { user.create_new_auth_token }
     let(:user_headers) do
       { HTTP_ACCEPT: 'application/json' }.merge!(user_credentials)
     end
+    
     before do
       put "/admin/communities/#{community.id}",
           params: {

--- a/spec/requests/admin_can_see_pending_request_spec.rb
+++ b/spec/requests/admin_can_see_pending_request_spec.rb
@@ -1,0 +1,34 @@
+RSpec.describe 'GET /communities', type: :request do
+  let(:community) { create(:community) }
+  let(:user) { create(:user, role: 'user', community_status: 'pending') }
+  let(:user2) { create(:user, role: 'user', community_status: 'pending') }
+  let(:user3) { create(:user, role: 'user', community_status: 'accepted') }
+  let(:admin) { create(:user, role: 'admin') }
+  let(:admin_credentials) { admin.create_new_auth_token }
+  let(:admin_headers) do
+    { HTTP_ACCEPT: 'application/json' }.merge!(admin_credentials)
+  end
+
+  describe 'admin can see list of pending requests' do 
+    before do
+      get "/communities",
+      headers: admin_headers
+    end 
+
+    it 'returns a 200 response status' do
+      expect(response).to have_http_status 200
+    end
+
+    it 'returns success message' do
+      expect(response_json['message']).to eq 'User is now accepted to your community'
+    end
+
+    it 'admin can accept user admission' do
+      expect(User.all.find(user.id).community_status).to eq 'accepted'
+    end
+  end 
+
+
+
+end
+

--- a/spec/requests/admin_can_see_pending_request_spec.rb
+++ b/spec/requests/admin_can_see_pending_request_spec.rb
@@ -44,4 +44,32 @@ RSpec.describe 'GET /admin/communities', type: :request do
       end
     end
   end
+
+  describe 'only admin can change community status' do
+    let(:community) { create(:community) }
+    let(:user) { create(:user, role: 'user', community_status: 'pending') }
+    let(:user_credentials) { user.create_new_auth_token }
+    let(:user_headers) do
+      { HTTP_ACCEPT: 'application/json' }.merge!(user_credentials)
+    end
+    before do
+      put "/admin/communities/#{community.id}",
+          params: {
+            user_admission: {
+              community_id: community.id,
+              community_status: 'rejected',
+              user_id: user.id
+            }
+          },
+          headers: user_headers
+    end
+
+    it 'returns a 401 response status' do
+      expect(response).to have_http_status 401
+    end
+
+    it 'returns error message' do
+      expect(response_json['message']).to eq 'You are not authorized to do this, ask your admin'
+    end
+  end
 end

--- a/spec/requests/admin_can_see_pending_request_spec.rb
+++ b/spec/requests/admin_can_see_pending_request_spec.rb
@@ -1,9 +1,11 @@
-RSpec.describe 'GET /communities', type: :request do
+RSpec.describe 'GET /admin/communities', type: :request do
   let(:community) { create(:community) }
-  let(:user) { create(:user, role: 'user', community_status: 'pending') }
-  let(:user2) { create(:user, role: 'user', community_status: 'pending') }
-  let(:user3) { create(:user, role: 'user', community_status: 'accepted') }
-  let(:admin) { create(:user, role: 'admin') }
+  let!(:user) { create(:user, role: 'user', community_status: 'pending', community_id: community.id) }
+  let!(:user2) { create(:user, role: 'user', community_status: 'pending', community_id: community.id) }
+  let!(:user3) { create(:user, role: 'user', community_status: 'accepted', community_id: community.id) }
+  let!(:user4) { create(:user, role: 'user', community_status: 'pending') }
+
+  let(:admin) { create(:user, role: 'admin', community_id: community.id) }
   let(:admin_credentials) { admin.create_new_auth_token }
   let(:admin_headers) do
     { HTTP_ACCEPT: 'application/json' }.merge!(admin_credentials)
@@ -11,7 +13,7 @@ RSpec.describe 'GET /communities', type: :request do
 
   describe 'admin can see list of pending requests' do 
     before do
-      get "/communities",
+      get "/admin/communities",
       headers: admin_headers
     end 
 
@@ -19,13 +21,13 @@ RSpec.describe 'GET /communities', type: :request do
       expect(response).to have_http_status 200
     end
 
-    it 'returns success message' do
+    it 'returns all pending users to a community' do
       expect(response_json['requests'].count).to eq 2
     end
 
-    # it 'admin can accept user admission' do
-    #   expect(User.all.find(user.id).community_status).to eq 'accepted'
-    # end
+    it 'returns correct community id' do
+      expect(response_json['requests'].first['community_id']).to eq community.id
+    end
   end 
 
 

--- a/spec/requests/admin_can_see_pending_request_spec.rb
+++ b/spec/requests/admin_can_see_pending_request_spec.rb
@@ -20,12 +20,12 @@ RSpec.describe 'GET /communities', type: :request do
     end
 
     it 'returns success message' do
-      expect(response_json['message']).to eq 'User is now accepted to your community'
+      expect(response_json['requests'].count).to eq 2
     end
 
-    it 'admin can accept user admission' do
-      expect(User.all.find(user.id).community_status).to eq 'accepted'
-    end
+    # it 'admin can accept user admission' do
+    #   expect(User.all.find(user.id).community_status).to eq 'accepted'
+    # end
   end 
 
 


### PR DESCRIPTION
## [PT board URL](https://www.pivotaltracker.com/story/show/172274707)
### User Story
```
As a coop chairman
In order to connect my buildings inhabitants
I would like to add families to the account
```

## Changes proposed in this pull request:
* Modifies ping and pong controller so only users with status accepted can access
* Creating admin namespace for admin actions
* Index action for admin to see pending requests
* Update action for admin to accept or reject users to community

## What I have learned working on this feature:
* How to use a namespace to separate actions to different roles