### PR TITLE
Api provides user to cancel request

### DIFF
--- a/app/controllers/pongs_controller.rb
+++ b/app/controllers/pongs_controller.rb
@@ -46,13 +46,11 @@ class PongsController < ApplicationController
 
   def is_part_of_community?
     if current_user.community_status == 'accepted'
-
     else
       render json: {
         message:
           'You are not part of a community yet, ask your admin for more information'
-      },
-             status: 401
+      }, status: 401
     end
   end
 

--- a/app/controllers/pongs_controller.rb
+++ b/app/controllers/pongs_controller.rb
@@ -27,9 +27,9 @@ class PongsController < ApplicationController
   def destroy
     if @pong.status == 'accepted'
       render json: {
-               message:
-                 'This request has alredy been accapted, reach out to your neighbour for additional changes'
-             }
+        message:
+          'This request has alredy been accapted, reach out to your neighbour for additional changes'
+      }
     else
       @pong.destroy
       render json: { message: 'Your request is removed' }
@@ -38,6 +38,8 @@ class PongsController < ApplicationController
 
   def show
     render json: @pong, serializer: PongShowSerializer
+  rescue StandardError => e
+    render json: { message: 'You have not requested anything from a neighbour' }
   end
 
   private
@@ -47,9 +49,9 @@ class PongsController < ApplicationController
 
     else
       render json: {
-               message:
-                 'You are not part of a community yet, ask your admin for more information'
-             },
+        message:
+          'You are not part of a community yet, ask your admin for more information'
+      },
              status: 401
     end
   end

--- a/app/controllers/pongs_controller.rb
+++ b/app/controllers/pongs_controller.rb
@@ -3,9 +3,9 @@
 class PongsController < ApplicationController
   before_action :authenticate_user!
   before_action :is_part_of_community?
-  before_action :verify_ping_and_user, only: [:create]
-  before_action :get_pong_owner, only: [:create]
-  before_action :get_ping, only: [:create]
+  before_action :verify_ping_and_user, only: %i[create]
+  before_action :get_pong_owner, only: %i[create]
+  before_action :get_ping, only: %i[create]
 
   def create
     if @pong_owner.has_active_pongs?
@@ -24,16 +24,29 @@ class PongsController < ApplicationController
   end
 
   def destroy
-    pong = User.find(params[:id]).pongs.last.destroy
-    render json: { message: 'Your request is removed' }
+    pong = User.find(params[:id]).pongs.last
+    if pong.status == 'accepted'
+      render json: {
+               message:
+                 'This request has alredy been accapted, reach out to your neighbour for additional changes'
+             }
+    else
+      pong.destroy
+      render json: { message: 'Your request is removed' }
+    end
   end
 
   private
 
   def is_part_of_community?
     if current_user.community_status == 'accepted'
+
     else
-      render json: { message: 'You are not part of a community yet, ask your admin for more information' }, status: 401
+      render json: {
+               message:
+                 'You are not part of a community yet, ask your admin for more information'
+             },
+             status: 401
     end
   end
 

--- a/app/controllers/pongs_controller.rb
+++ b/app/controllers/pongs_controller.rb
@@ -23,6 +23,11 @@ class PongsController < ApplicationController
     render json: ping, serializer: PingShowSerializer
   end
 
+  def destroy
+    pong = User.find(params[:id]).pongs.last.destroy
+    render json: { message: 'Your request is removed' }
+  end
+
   private
 
   def is_part_of_community?

--- a/app/controllers/pongs_controller.rb
+++ b/app/controllers/pongs_controller.rb
@@ -6,6 +6,7 @@ class PongsController < ApplicationController
   before_action :verify_ping_and_user, only: %i[create]
   before_action :get_pong_owner, only: %i[create]
   before_action :get_ping, only: %i[create]
+  before_action :last_pong, only: %i[show destroy]
 
   def create
     if @pong_owner.has_active_pongs?
@@ -24,16 +25,19 @@ class PongsController < ApplicationController
   end
 
   def destroy
-    pong = User.find(params[:id]).pongs.last
-    if pong.status == 'accepted'
+    if @pong.status == 'accepted'
       render json: {
                message:
                  'This request has alredy been accapted, reach out to your neighbour for additional changes'
              }
     else
-      pong.destroy
+      @pong.destroy
       render json: { message: 'Your request is removed' }
     end
+  end
+
+  def show
+    render json: @pong, serializer: PongShowSerializer
   end
 
   private
@@ -83,5 +87,9 @@ class PongsController < ApplicationController
 
   def render_error(error)
     render json: { message: error }
+  end
+
+  def last_pong
+    @pong = User.find(params[:id]).pongs.last
   end
 end

--- a/app/serializers/pong_show_serializer.rb
+++ b/app/serializers/pong_show_serializer.rb
@@ -1,0 +1,3 @@
+class PongShowSerializer < ActiveModel::Serializer
+  attributes :id, :item1, :item2, :item3, :status
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,7 @@
 Rails.application.routes.draw do
     mount_devise_token_auth_for 'User', at: '/auth', skip: [:omniauth_callbacks]
     resources :pings, only: [:create, :index, :update, :show]
-    resources :pongs, only: [:create, :update, :destroy]
+    resources :pongs, only: [:create, :update, :destroy, :show]
     resources :communities, only: [:index]
     namespace :admin do
         resources :communities, only: [:index, :update]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,7 @@
 Rails.application.routes.draw do
     mount_devise_token_auth_for 'User', at: '/auth', skip: [:omniauth_callbacks]
     resources :pings, only: [:create, :index, :update, :show]
-    resources :pongs, only: [:create, :update]
+    resources :pongs, only: [:create, :update, :destroy]
     resources :communities, only: [:index]
     namespace :admin do
         resources :communities, only: [:index, :update]

--- a/spec/requests/user_can_cancel_request_spec.rb
+++ b/spec/requests/user_can_cancel_request_spec.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+RSpec.describe 'DELETE /pongs/:id' do
+  let(:user) { create(:user, role: 'user', community_status: 'accepted') }
+  let(:user_credentials) { user.create_new_auth_token }
+  let(:user_headers) do
+    { HTTP_ACCEPT: 'application/json' }.merge!(user_credentials)
+  end
+  let(:ping) { create(:ping) }
+  let!(:pong) { create(:pong, ping_id: ping.id, user_id: user.id, active: false, status: 'accepted') }
+  let!(:pong2) { create(:pong, ping_id: ping.id, user_id: user.id) }
+
+  describe 'user can cancel their request' do
+    before do
+      delete "/pongs/#{user.id}",
+             headers: user_headers
+    end
+
+    it 'returns a 200 response status' do
+      expect(response).to have_http_status 200
+    end
+
+    it 'destroys request' do
+      expect(User.find(user.id).pongs.last).not_to eq pong2.id
+    end
+
+    it 'returns success message' do
+      expect(response_json['message']).to eq 'Your request is removed'
+    end
+  end
+end

--- a/spec/requests/user_can_cancel_request_spec.rb
+++ b/spec/requests/user_can_cancel_request_spec.rb
@@ -7,10 +7,10 @@ RSpec.describe 'DELETE /pongs/:id' do
     { HTTP_ACCEPT: 'application/json' }.merge!(user_credentials)
   end
   let(:ping) { create(:ping) }
-  
+
   describe 'user can cancel their request' do
     let!(:pong) { create(:pong, ping_id: ping.id, user_id: user.id, active: false, status: 'accepted') }
-  let!(:pong2) { create(:pong, ping_id: ping.id, user_id: user.id) }
+    let!(:pong2) { create(:pong, ping_id: ping.id, user_id: user.id) }
 
     before do
       delete "/pongs/#{user.id}",
@@ -29,6 +29,7 @@ RSpec.describe 'DELETE /pongs/:id' do
       expect(response_json['message']).to eq 'Your request is removed'
     end
   end
+
   describe 'user can cancel their request' do
     let!(:pong) { create(:pong, ping_id: ping.id, user_id: user.id, status: 'accepted') }
 

--- a/spec/requests/user_can_cancel_request_spec.rb
+++ b/spec/requests/user_can_cancel_request_spec.rb
@@ -7,10 +7,11 @@ RSpec.describe 'DELETE /pongs/:id' do
     { HTTP_ACCEPT: 'application/json' }.merge!(user_credentials)
   end
   let(:ping) { create(:ping) }
-  let!(:pong) { create(:pong, ping_id: ping.id, user_id: user.id, active: false, status: 'accepted') }
+  
+  describe 'user can cancel their request' do
+    let!(:pong) { create(:pong, ping_id: ping.id, user_id: user.id, active: false, status: 'accepted') }
   let!(:pong2) { create(:pong, ping_id: ping.id, user_id: user.id) }
 
-  describe 'user can cancel their request' do
     before do
       delete "/pongs/#{user.id}",
              headers: user_headers
@@ -26,6 +27,18 @@ RSpec.describe 'DELETE /pongs/:id' do
 
     it 'returns success message' do
       expect(response_json['message']).to eq 'Your request is removed'
+    end
+  end
+  describe 'user can cancel their request' do
+    let!(:pong) { create(:pong, ping_id: ping.id, user_id: user.id, status: 'accepted') }
+
+    before do
+      delete "/pongs/#{user.id}",
+             headers: user_headers
+    end
+
+    it 'can not delete accepted pong' do
+      expect(response_json['message']).to eq 'This request has alredy been accapted, reach out to your neighbour for additional changes'
     end
   end
 end

--- a/spec/requests/user_can_see_their_pong_spec.rb
+++ b/spec/requests/user_can_see_their_pong_spec.rb
@@ -1,0 +1,17 @@
+RSpec.describe 'GET /pongs', type: :request do
+  let(:user) { create(:user, role: 'user', community_status: 'accepted') }
+  let(:user_credentials) { user.create_new_auth_token }
+  let(:user_headers) do
+    { HTTP_ACCEPT: 'application/json' }.merge!(user_credentials)
+  end
+  let!(:pong) { create(:pong, item1: 'smör', user_id: user.id)  }
+  
+  describe 'can see last pong' do
+    
+    before { get "/pongs/#{user.id}", headers: user_headers }
+
+    it 'return last pong' do
+      expect(response_json['pong']['item1']).to eq 'smör'
+    end
+  end
+end

--- a/spec/requests/user_can_see_their_pong_spec.rb
+++ b/spec/requests/user_can_see_their_pong_spec.rb
@@ -4,14 +4,30 @@ RSpec.describe 'GET /pongs', type: :request do
   let(:user_headers) do
     { HTTP_ACCEPT: 'application/json' }.merge!(user_credentials)
   end
-  let!(:pong) { create(:pong, item1: 'smör', user_id: user.id)  }
   
   describe 'can see last pong' do
-    
+    let!(:pong) { create(:pong, item1: 'smör', user_id: user.id)  }
+
     before { get "/pongs/#{user.id}", headers: user_headers }
+
+    it 'returns a 200 response status' do
+      expect(response).to have_http_status 200
+    end
 
     it 'return last pong' do
       expect(response_json['pong']['item1']).to eq 'smör'
+    end
+  end
+
+  describe 'returns message if there are no pongs' do
+    before { get "/pongs/#{user.id}", headers: user_headers }
+
+    it 'returns a 200 response status' do
+      expect(response).to have_http_status 200
+    end
+
+    it 'return last pong' do
+      expect(response_json['message']).to eq 'You have not requested anything from a neighbour'
     end
   end
 end


### PR DESCRIPTION
## [PT board URL](https://www.pivotaltracker.com/story/show/172274902)
### User Story
```
As a resident
In order to change my requests
I would like to be able to cancel unaccepted requests
```
## Changes proposed in this pull request:
* Adds destroy action to pongs controller, user can cancel their active pong
* Adds show action to pongs controller, user can see their last pong
* Adds serializer for show action
## What I have learned working on this feature:
* How to do a delete action
* That begin rescue is good stuff
